### PR TITLE
Add pip dependency support

### DIFF
--- a/userbot/__init__.py
+++ b/userbot/__init__.py
@@ -186,3 +186,4 @@ USER_MODULES = []  # [Name of user module]
 MODULE_DESC = {}  # {Module name: MODULE_DESC}
 MODULE_DICT = {}  # {Module name: MODULE_USAGE}
 MODULE_INFO = {}  # {Module name: MODULE_INFO}
+MODULE_DEPS = {}  # {Module name: MODULE_DEPS}

--- a/userbot/__main__.py
+++ b/userbot/__main__.py
@@ -101,13 +101,18 @@ class _Modules:
 def installDeps():
     success = 0
     for r in MODULE_DEPS:
-        try:
-            bout = subprocess.check_output(PIP_COMMAND.format(MODULE_DEPS[r]).split())
-            output = bout.decode('ascii')
-            if not f"Requirement already satisfied: {MODULE_DEPS[r]}" in output:
-                success = success + 1
-        except subprocess.CalledProcessError:
-            log.error(f"Error installing dependency {MODULE_DEPS[r]}")
+        if MODULE_DEPS[r].source = "pip":
+            try:
+                bout = subprocess.check_output(PIP_COMMAND.format(MODULE_DEPS[r]).split())
+                output = bout.decode('ascii')
+                if not f"Requirement already satisfied: {MODULE_DEPS[r]}" in output:
+                    success = success + 1
+            except subprocess.CalledProcessError:
+                log.error(f"Error installing dependency {MODULE_DEPS[r]}")
+        elif MODULE_DEPS[r].source == "repo":
+            # todo
+        else:
+            log.warn(f"Module {r} depends on {MODULE_DEPS[r].name} from unknown source {MODULE_DEPS[r].source}.")
     return success
 
 if __name__ == "__main__":

--- a/userbot/__main__.py
+++ b/userbot/__main__.py
@@ -102,7 +102,7 @@ class _Modules:
 def installDeps():
     success = 0
     for r in MODULE_DEPS:
-        if MODULE_DEPS[r].source = "pip":
+        if MODULE_DEPS[r].source == "pip":
             try:
                 bout = subprocess.check_output(PIP_COMMAND.format(MODULE_DEPS[r]).split())
                 output = bout.decode('ascii')

--- a/userbot/__main__.py
+++ b/userbot/__main__.py
@@ -1,5 +1,6 @@
 # Copyright 2020 nunopenim @github
 # Copyright 2020 prototype74 @github
+# Copyright 2021 githubcatw @github
 #
 # Licensed under the PEL (Penim Enterprises License), v1.0
 #

--- a/userbot/include/aux_funcs.py
+++ b/userbot/include/aux_funcs.py
@@ -208,6 +208,23 @@ def module_info(name: str, version: str) -> dict:
     """
     return {"name": name, "version": version}
 
+def dependency(name: str, source: str) -> dict:
+    """
+    Put name and source of a dependency to a new dictionary
+
+    Args:
+        name (str): name of module
+        source (str): should be either "pip" or "repo"
+
+    Example:
+        dependency("Pillow", "pip")
+        dependency("example", "repo")
+
+    Returns:
+        A dictionary with 2 keys
+    """
+    return {"name": name, "source": source}
+
 def shell_runner(commands: list):
     """
     Execute shell commands from given list with strings

--- a/userbot/include/aux_funcs.py
+++ b/userbot/include/aux_funcs.py
@@ -1,5 +1,6 @@
 # Copyright 2020 nunopenim @github
 # Copyright 2020 prototype74 @github
+# Copyright 2021 githubcatw @github
 #
 # Licensed under the PEL (Penim Enterprises License), v1.0
 #


### PR DESCRIPTION
I have added a feature where modules can define dependencies and the userbot will install them if needed.

This PR adds a new field - `MODULE_DEPS`. Usage:
```python
from userbot import MODULE_DEPS
from userbot.include.aux_funcs import dependency
from os.path import basename

# [...]

MODULE_DEPS.update({basename(__file__)[:-3]: dependency(name="Pillow", source="pip")})
MODULE_DEPS.update({basename(__file__)[:-3]: dependency(name="beautifulsoup4", source="pip")})
MODULE_DEPS.update({basename(__file__)[:-3]: dependency(name="other_dependency", source="pip")})
# ...
```

Dependencies have customizable types. I wanted to add a `repo` type for when a module depends on another (like `memes_text` on `correction` in [my repo](https://github.com/userbot8895/HyperBot_Plus)) but I'm sure you can make it better than me.